### PR TITLE
Rewrite thumbnail generation

### DIFF
--- a/lib/iteration.py
+++ b/lib/iteration.py
@@ -80,13 +80,18 @@ class resultFILTER:
             # else:
             #     return
     def getthumb(self,file):
-        if os.path.isfile(file + '.png'):
-            '''Check for existing thumbnail'''
-            self.thumb = file + '.png'
-        else:
+        '''Check for existing thumbnail'''
+        self.validext = ['.jpg', '.jpeg', '.png']
+        self.thumb = None
+        for ext in self.validext:
+            if os.path.isfile(file + ext):
+                self.thumb = file + ext
+                break
+
+        if self.thumb == None:
             try:
                 '''Try to generate on our own'''
-                self.thumb = file + '.png'
+                self.thumb = file + '.jpg'
                 subprocess.call(['ffmpeg', '-i', file, '-ss', '00:00:20', '-vframes', '1', self.thumb])
             except subprocess.CalledProcessError as exc:
                 warning("Thumbnail generation error: " + exc.returncode)

--- a/lib/iteration.py
+++ b/lib/iteration.py
@@ -80,8 +80,23 @@ class resultFILTER:
             # else:
             #     return
     def getthumb(self,file):
-        self.thumb = resultFILTER().build_video_thumbnail_path(file)
-        xbmc.getCacheThumbName(file)
+        if os.path.isfile(file + '.png'):
+            '''Check for existing thumbnail'''
+            self.thumb = file + '.png'
+        else:
+            try:
+                '''Try to generate on our own'''
+                self.thumb = file + '.png'
+                subprocess.call(['ffmpeg', '-i', file, '-ss', '00:00:20', '-vframes', '1', self.thumb])
+            except subprocess.CalledProcessError as exc:
+                warning("Thumbnail generation error: " + exc.returncode)
+                warning(exc.output)
+                info("Thumbnail generation passed off to Kodi")
+
+                '''Fallback to Kodi generation just in case'''
+                self.thumb = resultFILTER().build_video_thumbnail_path(file)
+                xbmc.getCacheThumbName(file)
+
         return self.thumb
     '''Getting Files'''
     def verifyFile(self,file,sp):

--- a/lib/iteration.py
+++ b/lib/iteration.py
@@ -81,28 +81,57 @@ class resultFILTER:
             #     return
     def getthumb(self,file):
         '''Check for existing thumbnail'''
-        self.validext = ['.jpg', '.jpeg', '.png']
-        self.thumb = None
-        for ext in self.validext:
-            if os.path.isfile(file + ext):
-                self.thumb = file + ext
+        validext = ['.jpg', '.jpeg', '.png']
+        thumb = None
+        thumbname = os.path.splitext(file)[0] + '-thumb'
+
+        for ext in validext:
+            if os.path.isfile(thumbname + ext):
+                thumb = thumbname + ext
                 break
 
-        if self.thumb == None:
+        if thumb == None:
             try:
                 '''Try to generate on our own'''
-                self.thumb = file + '.jpg'
-                subprocess.call(['ffmpeg', '-i', file, '-ss', '00:00:20', '-vframes', '1', self.thumb])
+                import platform
+
+                '''Generate thumbnail hash'''
+                cachename = file.lower()
+                bytes = bytearray(cachename.encode())
+                crc = 0xffffffff
+                for b in bytes:
+                    crc = crc ^ (b << 24)
+                    for i in range(8):
+                        if (crc & 0x80000000 ):
+                            crc = (crc << 1) ^ 0x04C11DB7
+                        else:
+                            crc = crc << 1;
+                    crc = crc & 0xFFFFFFFF
+                thumb = '%08x' % crc + '.jpg'
+
+                '''Follow Kodi path standards'''
+                thumbdir = os.path.join(cachedir, thumb[0])
+
+                if not xbmcvfs.exists(thumbdir):
+                    xbmcvfs.mkdir(thumbdir)
+
+                thumb = os.path.join(thumbdir, thumb)
+
+                '''subprocess.call doesn't work correctly on Windows without shell=True'''
+                if platform.system() == 'Windows':
+                    subprocess.call(['ffmpeg', '-i', file, '-ss', '00:00:20', '-vframes', '1', thumb], shell=True)
+                else:
+                    subprocess.call(['ffmpeg', '-i', file, '-ss', '00:00:20', '-vframes', '1', thumb])
             except subprocess.CalledProcessError as exc:
                 warning("Thumbnail generation error: " + exc.returncode)
                 warning(exc.output)
                 info("Thumbnail generation passed off to Kodi")
 
                 '''Fallback to Kodi generation just in case'''
-                self.thumb = resultFILTER().build_video_thumbnail_path(file)
+                thumb = resultFILTER().build_video_thumbnail_path(file)
                 xbmc.getCacheThumbName(file)
 
-        return self.thumb
+        return thumb
     '''Getting Files'''
     def verifyFile(self,file,sp):
         self.dump = False

--- a/lib/sys_init.py
+++ b/lib/sys_init.py
@@ -48,26 +48,31 @@ addonid    = addon.getAddonInfo("id")
 addonpath  = addon.getAddonInfo("path")
 addir      = xbmc.translatePath(addon.getAddonInfo("profile"))
 adset      = xbmc.translatePath(os.path.join(addir,"settings.xml"))
-adtest      = xbmc.translatePath(os.path.join(addir,"testing.sfnfo"))
+adtest     = xbmc.translatePath(os.path.join(addir,"testing.sfnfo"))
 adtes      = xbmc.translatePath(os.path.join(addir,"movie.sfnfo"))
 dbdir      = xbmc.translatePath(os.path.join(addir,"{}.db".format(dbName)))
 libdir     = xbmc.translatePath(os.path.join(addonpath,'lib'))
 resdir     = xbmc.translatePath(os.path.join(addonpath,'resources'))
 sqldir     = xbmc.translatePath(os.path.join(libdir,'pymysql'))
+cachedir   = xbmc.translatePath(os.path.join(os.path.sep.join(dbdir.split(os.path.sep)[:-3]),'Thumbnails','plugin.video.specialfeatures'))
 
 sys.path.append(libdir)
 sys.path.append(resdir)
 sys.path.append(sqldir)
+sys.path.append(cachedir)
+
+if not xbmcvfs.exists(cachedir):
+    xbmcvfs.mkdir(cachedir)
 
 '''GUI'''
 home       = xbmcgui.Window(10000)
 dialpro    = xbmcgui.DialogProgress()
 dialbg     = xbmcgui.DialogProgressBG()
-dialog     = xbmcgui.Dialog()        
+dialog     = xbmcgui.Dialog()
 
 ''' Plugin'''
 urlhandle  = "plugin://plugin.video.specialfeatures/?"
-althandle  = "plugin://plugin.video.specialfeatures/" 
+althandle  = "plugin://plugin.video.specialfeatures/"
 
 '''XBMC'''
 monitor    = xbmc.Monitor()


### PR DESCRIPTION
This allows a three-tiered thumbnail generation sequence. First (and most importantly), it now allows you to drop a custom image in the extras folder. If this image is found, generation is skipped entirely. Custom images should look like this:

```
    The Pirates of the Caribbean\Extras\
                                        >Theactrical Trailer.mkv/mp4/ etc
                                        >Theactrical Trailer.mkv.png
                                        >3D Verison\BDMV\index.bdmv
                                        >3D Verison\BDMV\index.bdmv.jpg
                                        >Bonus Disc\VIDEO_TS\VIDEO_TS.IFO
```

Currently, `jpg`, `jpeg`, and `png` are supported (in that order). If no custom image is found, it then tries to generate one on its own. This is done based on the 20-second mark of the video. If THIS fails (shouldn't ever happen unless for some reason ffmpeg isn't available AT ALL, it logs the failure and falls back on generating through Kodi as the current system does.