### PR TITLE
Allow custom thumbnails

### DIFF
--- a/lib/iteration.py
+++ b/lib/iteration.py
@@ -14,7 +14,7 @@ class resultFILTER:
         if self.vR is True:
             self.sortDir(query,result)
             self.verifyDir(self.checker)
-    '''Checking results''' 
+    '''Checking results'''
     def verifyRes(self,query,result):
         if 'result' in result:
             if result['result']['limits']['total'] != 0:
@@ -80,9 +80,21 @@ class resultFILTER:
             # else:
             #     return
     def getthumb(self,file):
-        self.thumb = resultFILTER().build_video_thumbnail_path(file)
-        xbmc.getCacheThumbName(file)
-        return self.thumb
+        '''Check for existing thumbnail'''
+        validext = ['.jpg', '.jpeg', '.png']
+        thumb = None
+        thumbname = os.path.splitext(file)[0] + '-thumb'
+
+        for ext in validext:
+            if os.path.isfile(thumbname + ext):
+                thumb = thumbname + ext
+                break
+
+        if thumb == None:
+            thumb = resultFILTER().build_video_thumbnail_path(file)
+            xbmc.getCacheThumbName(file)
+
+        return thumb
     '''Getting Files'''
     def verifyFile(self,file,sp):
         self.dump = False
@@ -96,7 +108,7 @@ class resultFILTER:
         if not self.dump:
             return self.sfil
         return
-    '''Our Extras folder has folders checking for 
+    '''Our Extras folder has folders checking for
             bluray and then dvds'''
     def verifySub(self,direct,sp):
         if '/' in self.f:
@@ -302,10 +314,10 @@ class dbEnterExit:
                 self.chkList.append(self.item.get('file'))
                 self.index += 1
         except:
-            info('No TV Shows') 
+            info('No TV Shows')
         self.range = len(self.chkList)
-        info(self.chkList) 
-        info(self.range) 
+        info(self.chkList)
+        info(self.range)
         self.entry = self.sql.exeCute('all_special','','all')
         for self.item in self.entry:
             if mysql == 'true':
@@ -325,7 +337,7 @@ class dbEnterExit:
         self.trAsh = list()
         self.entry = self.sql.exeCute('all_movies','','all')
         for self.item in self.entry:
-            if mysql == 'true':     
+            if mysql == 'true':
                 self.verify = self.verIfy(self.item['file'])
                 self.doublechk = self.sql.exeCute('fw_special',self.item['file'],'one')
                 if self.verify == 0:
@@ -403,8 +415,8 @@ class dbEnterExit:
                                         'thumbnail'  : self.citem['thumbnail'],
                                         'role'       : self.citem['role'],
                                         'order'      : self.citem['ordr'],
-                                        }          
-                            self.cast.append(self.actor) 
+                                        }
+                            self.cast.append(self.actor)
                         self.input = {'file':self.item['file'], 'title':self.item['title'], 'year':self.item['year'],'plot':self.item['plot'],
                                       'rating':self.item['rating'], 'votes':self.item['votes'], 'dateadded':self.item['dateadded'], 'mpaa':self.item['mpaa'],
                                       'premiered':self.item['premiered'], 'userrating':self.item['userrating'],'top250':self.item['top250'], 'art':self.art,
@@ -425,8 +437,8 @@ class dbEnterExit:
                                         'thumbnail'  : self.citem[2],
                                         'role'       : self.citem[3],
                                         'order'      : self.citem[4],
-                                        }          
-                            self.cast.append(self.actor) 
+                                        }
+                            self.cast.append(self.actor)
                         self.input = {'file':self.item[0], 'title':self.item[1], 'year':self.item[2],'plot':self.item[3],
                                       'rating':self.item[4], 'votes':self.item[5], 'dateadded':self.item[5], 'mpaa':self.item[7],
                                       'premiered':self.item[8], 'userrating':self.item[9],'top250':self.item[10], 'art':self.art,
@@ -453,8 +465,8 @@ class dbEnterExit:
                                         'thumbnail'  : self.citem['thumbnail'],
                                         'role'       : self.citem['role'],
                                         'order'      : self.citem['ordr'],
-                                        }          
-                            self.cast.append(self.actor) 
+                                        }
+                            self.cast.append(self.actor)
                         self.input = {'file':self.item['file'], 'title':self.item['title'], 'year':self.item['year'],'plot':self.item['plot'],
                                       'rating':self.item['rating'], 'votes':self.item['votes'], 'dateadded':self.item['dateadded'], 'mpaa':self.item['mpaa'],
                                       'premiered':self.item['premiered'], 'userrating':self.item['userrating'],'top250':self.item['top250'], 'art':self.art,
@@ -475,8 +487,8 @@ class dbEnterExit:
                                         'thumbnail'  : self.citem[2],
                                         'role'       : self.citem[3],
                                         'order'      : self.citem[4],
-                                        }          
-                            self.cast.append(self.actor) 
+                                        }
+                            self.cast.append(self.actor)
                         self.input = {'file':self.item[0], 'title':self.item[1], 'year':self.item[2],'plot':self.item[3],
                                       'rating':self.item[4], 'votes':self.item[5], 'dateadded':self.item[5], 'mpaa':self.item[7],
                                       'premiered':self.item[8], 'userrating':self.item[9],'top250':self.item[10], 'art':self.art,
@@ -503,9 +515,9 @@ class dbEnterExit:
                                         'thumbnail'  : self.citem['thumbnail'],
                                         'role'       : self.citem['role'],
                                         'order'      : self.citem['ordr'],
-                                        }          
+                                        }
                             self.cast.append(self.actor)
-                        self.art.update({'thumb':self.item['thumb']})  
+                        self.art.update({'thumb':self.item['thumb']})
                         self.input = {'file':self.item['file'], 'title':self.item['title'], 'path':self.item['bpath'],'sorttitle':self.item['sorttitle'],
                                       'plot':self.item['plot'], 'art':self.art, 'cast':self.cast
                                       }
@@ -523,9 +535,9 @@ class dbEnterExit:
                                         'thumbnail'  : self.citem[2],
                                         'role'       : self.citem[3],
                                         'order'      : self.citem[4],
-                                        }          
+                                        }
                             self.cast.append(self.actor)
-                        self.art.update({'thumb':self.item[5]}) 
+                        self.art.update({'thumb':self.item[5]})
                         self.input = {'file':self.item[0], 'title':self.item[1], 'path':self.item[2],'sorttitle':self.item[3],
                                       'plot':self.item[4], 'art':self.art, 'cast':self.cast
                                       }
@@ -606,7 +618,3 @@ class dbEnterExit:
         dbEnterExit().initDb('smallup',self.update)
         xbmc.executebuiltin('Container.Update({})'.format(xbmc.getInfoLabel('Container.FolderPath')))
         quit()
-
-
-
-    


### PR DESCRIPTION
This allows custom thumbnails to be used for extras. If an image is found, generation is skipped entirely. Custom images should look like this:

```
    The Pirates of the Caribbean\Extras\
                                        >Theactrical Trailer.mkv/mp4/ etc
                                        >Theactrical Trailer-thumb.png
                                        >3D Verison\BDMV\index.bdmv
                                        >3D Verison\BDMV\index-thumb.jpg
                                        >Bonus Disc\VIDEO_TS\VIDEO_TS.IFO
```

Currently, `jpg`, `jpeg`, and `png` are supported (in that order).